### PR TITLE
Add UART16550 UVM driver example

### DIFF
--- a/uart16550/README.md
+++ b/uart16550/README.md
@@ -1,0 +1,21 @@
+# UART 16550 UVM Driver Example
+
+This directory contains a minimal example of an UART 16550 driver written in SystemVerilog using the UVM framework. The code provides a basic transaction-level driver along with a simple testbench skeleton.
+
+## Files
+- `uart16550_if.sv` – UART virtual interface used by the driver.
+- `uart_transaction.sv` – Sequence item representing a UART byte transfer.
+- `uart_driver.sv` – UVM driver that drives transactions onto the interface.
+- `uart_sequencer.sv` – UVM sequencer associated with the driver.
+- `uart_sequence.sv` – Example sequence generating random UART transfers.
+- `uart_pkg.sv` – Package bundling all components.
+- `uart_test.sv` – Testbench top and basic test class.
+
+## Building
+The example can be compiled with **Verilator** for linting or simulation:
+
+```sh
+verilator -sv -Wall uart_test.sv --lint-only
+```
+
+This command performs syntax checking without running a simulation.

--- a/uart16550/uart16550_if.sv
+++ b/uart16550/uart16550_if.sv
@@ -1,0 +1,20 @@
+interface uart16550_if(
+    input  logic clk,
+    input  logic rst_n
+);
+    // UART lines
+    logic rxd; // receive data
+    logic txd; // transmit data
+    logic cts; // clear to send
+    logic rts; // request to send
+
+    // Simple task to drive txd
+    task drive_txd(input logic val);
+        txd <= val;
+    endtask
+
+    // Simple function to sample rxd
+    function logic sample_rxd();
+        return rxd;
+    endfunction
+endinterface

--- a/uart16550/uart_driver.sv
+++ b/uart16550/uart_driver.sv
@@ -1,0 +1,41 @@
+`ifndef UART_DRIVER_SV
+`define UART_DRIVER_SV
+
+class uart_driver extends uvm_driver#(uart_transaction);
+    virtual uart16550_if vif;
+
+    function new(string name, uvm_component parent);
+        super.new(name, parent);
+    endfunction
+
+    virtual function void build_phase(uvm_phase phase);
+        super.build_phase(phase);
+        if(!uvm_config_db#(virtual uart16550_if)::get(this, "", "vif", vif))
+            `uvm_fatal("NOVIF", "Virtual interface not set for uart_driver")
+    endfunction
+
+    task run_phase(uvm_phase phase);
+        uart_transaction tr;
+        forever begin
+            seq_item_port.get_next_item(tr);
+            drive_byte(tr);
+            seq_item_port.item_done();
+        end
+    endtask
+
+    task drive_byte(uart_transaction tr);
+        // Simple start bit
+        vif.drive_txd(1'b0);
+        @(posedge vif.clk);
+        // Send data bits LSB first
+        foreach(tr.data[i]) begin
+            vif.drive_txd(tr.data[i]);
+            @(posedge vif.clk);
+        end
+        // Simple stop bit(s)
+        vif.drive_txd(1'b1);
+        repeat(tr.stop_bits==2 ? 2 : 1) @(posedge vif.clk);
+    endtask
+endclass
+
+`endif // UART_DRIVER_SV

--- a/uart16550/uart_pkg.sv
+++ b/uart16550/uart_pkg.sv
@@ -1,0 +1,9 @@
+package uart_pkg;
+    import uvm_pkg::*;
+    `include "uvm_macros.svh"
+
+    `include "uart_transaction.sv"
+    `include "uart_sequencer.sv"
+    `include "uart_driver.sv"
+    `include "uart_sequence.sv"
+endpackage

--- a/uart16550/uart_sequence.sv
+++ b/uart16550/uart_sequence.sv
@@ -1,0 +1,22 @@
+`ifndef UART_SEQUENCE_SV
+`define UART_SEQUENCE_SV
+
+class uart_sequence extends uvm_sequence#(uart_transaction);
+    `uvm_object_utils(uart_sequence)
+
+    function new(string name="uart_sequence");
+        super.new(name);
+    endfunction
+
+    task body();
+        uart_transaction tr;
+        repeat(10) begin
+            tr = uart_transaction::type_id::create("tr");
+            assert(tr.randomize());
+            start_item(tr);
+            finish_item(tr);
+        end
+    endtask
+endclass
+
+`endif // UART_SEQUENCE_SV

--- a/uart16550/uart_sequencer.sv
+++ b/uart16550/uart_sequencer.sv
@@ -1,0 +1,12 @@
+`ifndef UART_SEQUENCER_SV
+`define UART_SEQUENCER_SV
+
+class uart_sequencer extends uvm_sequencer#(uart_transaction);
+    `uvm_component_utils(uart_sequencer)
+
+    function new(string name, uvm_component parent);
+        super.new(name, parent);
+    endfunction
+endclass
+
+`endif // UART_SEQUENCER_SV

--- a/uart16550/uart_test.sv
+++ b/uart16550/uart_test.sv
@@ -1,0 +1,69 @@
+`timescale 1ns/1ps
+
+import uvm_pkg::*;
+`include "uvm_macros.svh"
+`include "uart_pkg.sv"
+
+module uart_testbench;
+    logic clk = 0;
+    logic rst_n = 0;
+
+    always #5 clk = ~clk; // 100MHz
+
+    uart16550_if uart_if(.clk(clk), .rst_n(rst_n));
+
+    initial begin
+        rst_n = 0;
+        repeat(5) @(posedge clk);
+        rst_n = 1;
+    end
+
+    initial begin
+        run_test("uart_basic_test");
+    end
+endmodule
+
+class uart_env extends uvm_env;
+    uart_sequencer sqr;
+    uart_driver    drv;
+
+    `uvm_component_utils(uart_env)
+
+    function new(string name, uvm_component parent);
+        super.new(name, parent);
+    endfunction
+
+    virtual function void build_phase(uvm_phase phase);
+        super.build_phase(phase);
+        sqr = uart_sequencer::type_id::create("sqr", this);
+        drv = uart_driver   ::type_id::create("drv", this);
+        uvm_config_db#(virtual uart16550_if)::set(this, "drv", "vif", uart_if);
+    endfunction
+
+    virtual function void connect_phase(uvm_phase phase);
+        drv.seq_item_port.connect(sqr.seq_item_export);
+    endfunction
+endclass
+
+class uart_basic_test extends uvm_test;
+    `uvm_component_utils(uart_basic_test)
+
+    uart_env env;
+
+    function new(string name, uvm_component parent);
+        super.new(name, parent);
+    endfunction
+
+    virtual function void build_phase(uvm_phase phase);
+        super.build_phase(phase);
+        env = uart_env::type_id::create("env", this);
+    endfunction
+
+    task run_phase(uvm_phase phase);
+        uart_sequence seq;
+        phase.raise_objection(this);
+        seq = uart_sequence::type_id::create("seq");
+        seq.start(env.sqr);
+        phase.drop_objection(this);
+    endtask
+endclass

--- a/uart16550/uart_transaction.sv
+++ b/uart16550/uart_transaction.sv
@@ -1,0 +1,20 @@
+`ifndef UART_TRANSACTION_SV
+`define UART_TRANSACTION_SV
+
+class uart_transaction extends uvm_sequence_item;
+    rand bit [7:0] data;
+    rand bit       parity_en;
+    rand bit [1:0] stop_bits; // 0:1 stop, 1:1.5 stop, 2:2 stop
+
+    `uvm_object_utils_begin(uart_transaction)
+        `uvm_field_int(data,       UVM_ALL_ON)
+        `uvm_field_int(parity_en,  UVM_ALL_ON)
+        `uvm_field_int(stop_bits,  UVM_ALL_ON)
+    `uvm_object_utils_end
+
+    function new(string name="uart_transaction");
+        super.new(name);
+    endfunction
+endclass
+
+`endif // UART_TRANSACTION_SV


### PR DESCRIPTION
## Summary
- add a SystemVerilog UART 16550 interface
- implement a UVM driver, sequencer and example sequence
- provide a minimal UVM testbench
- document the example and how to run lint with Verilator

## Testing
- `verilator -sv -Wall uart_test.sv --lint-only` *(fails: cannot find `uvm_macros.svh`)*

------
https://chatgpt.com/codex/tasks/task_e_6879ffa2f520832f8fcc78d9ff576031