### PR TITLE
Accept open arrays for burst tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+VCS=vcs
+VCS_FLAGS=-sverilog -timescale=1ns/1ps -debug_access+all -fsdb
+SRC=src/axi4_slave.v src/axi4_master_if.sv tb/tb_axi4.sv
+
+all: simv
+
+simv: $(SRC)
+	$(VCS) $(VCS_FLAGS) $(SRC) -o simv
+
+run: simv
+	./simv -l simv.log
+
+verdi: simv
+	verdi -sv $(SRC) -ssf wave.fsdb -ssw tb/signals.rc &
+
+clean:
+	rm -rf simv simv.daidir csrc simv.log wave.fsdb

--- a/src/axi4_master_if.sv
+++ b/src/axi4_master_if.sv
@@ -1,0 +1,115 @@
+interface axi4_master_if#(
+    parameter ADDR_WIDTH = 32,
+    parameter DATA_WIDTH = 32,
+    parameter MAX_BURST  = 16
+);
+    logic aclk;
+    logic aresetn;
+    logic awvalid;
+    logic awready;
+    logic [ADDR_WIDTH-1:0] awaddr;
+    logic [7:0] awlen;
+    logic [2:0] awsize;
+    logic [1:0] awburst;
+    logic wvalid;
+    logic wready;
+    logic [DATA_WIDTH-1:0] wdata;
+    logic [3:0] wstrb;
+    logic wlast;
+    logic bvalid;
+    logic bready;
+    logic [1:0] bresp;
+    logic arvalid;
+    logic arready;
+    logic [ADDR_WIDTH-1:0] araddr;
+    logic [7:0] arlen;
+    logic [2:0] arsize;
+    logic [1:0] arburst;
+    logic rvalid;
+    logic rready;
+    logic [DATA_WIDTH-1:0] rdata;
+    logic [1:0] rresp;
+    logic rlast;
+
+    // Write single data
+    task automatic write_single(input [ADDR_WIDTH-1:0] addr, input [DATA_WIDTH-1:0] data);
+        awaddr  <= addr;
+        awlen   <= 0;
+        awsize  <= 3'b010; // 4 bytes
+        awburst <= 2'b01;  // INCR
+        awvalid <= 1;
+        @(posedge aclk); while(!awready) @(posedge aclk);
+        awvalid <= 0;
+        wdata  <= data;
+        wstrb  <= 4'hF;
+        wvalid <= 1;
+        wlast  <= 1;
+        @(posedge aclk); while(!wready) @(posedge aclk);
+        wvalid <= 0;
+        wlast  <= 0;
+        bready <= 1;
+        @(posedge aclk); while(!bvalid) @(posedge aclk);
+        bready <= 0;
+    endtask
+
+    // Read single data
+    task automatic read_single(input [ADDR_WIDTH-1:0] addr, output [DATA_WIDTH-1:0] data);
+        araddr  <= addr;
+        arlen   <= 0;
+        arsize  <= 3'b010;
+        arburst <= 2'b01;
+        arvalid <= 1;
+        @(posedge aclk); while(!arready) @(posedge aclk);
+        arvalid <= 0;
+        rready  <= 1;
+        @(posedge aclk); while(!rvalid) @(posedge aclk);
+        data = rdata;
+        @(posedge aclk);
+        rready <= 0;
+    endtask
+
+    // Burst write. Accept an open array so any sized buffer can be passed in.
+    task automatic write_burst(input [ADDR_WIDTH-1:0] addr,
+                               input [DATA_WIDTH-1:0] data [],
+                               input int beats);
+        awaddr  <= addr;
+        awlen   <= beats-1;
+        awsize  <= 3'b010;
+        awburst <= 2'b01;
+        awvalid <= 1;
+        @(posedge aclk); while(!awready) @(posedge aclk);
+        awvalid <= 0;
+        for(int i=0;i<beats;i++) begin
+            wdata  <= data[i];
+            wstrb  <= 4'hF;
+            wlast  <= (i==beats-1);
+            wvalid <= 1;
+            @(posedge aclk); while(!wready) @(posedge aclk);
+            wvalid <= 0;
+        end
+        wlast <= 0;
+        bready <= 1;
+        @(posedge aclk); while(!bvalid) @(posedge aclk);
+        bready <= 0;
+    endtask
+
+    // Burst read. Return results via an open array as well.
+    task automatic read_burst(input [ADDR_WIDTH-1:0] addr,
+                              output [DATA_WIDTH-1:0] data [],
+                              input int beats);
+        araddr  <= addr;
+        arlen   <= beats-1;
+        arsize  <= 3'b010;
+        arburst <= 2'b01;
+        arvalid <= 1;
+        @(posedge aclk); while(!arready) @(posedge aclk);
+        arvalid <= 0;
+        for(int i=0;i<beats;i++) begin
+            rready <= 1;
+            @(posedge aclk); while(!rvalid) @(posedge aclk);
+            data[i] = rdata;
+        end
+        rready <= 0;
+    endtask
+
+endinterface

--- a/src/axi4_slave.v
+++ b/src/axi4_slave.v
@@ -1,0 +1,168 @@
+module axi4_slave #(
+    parameter AXI_ADDR_WIDTH = 32,
+    parameter AXI_DATA_WIDTH = 32,
+    parameter MEM_DEPTH      = 16384  // 16K bytes
+) (
+    // Global signals
+    input  wire                      aclk,
+    input  wire                      aresetn,
+    
+    // Write Address Channel
+    input  wire                      awvalid,
+    output reg                       awready,
+    input  wire [AXI_ADDR_WIDTH-1:0] awaddr,
+    input  wire [7:0]                awlen,
+    input  wire [2:0]                awsize,
+    input  wire [1:0]                awburst,
+    
+    // Write Data Channel
+    input  wire                      wvalid,
+    output reg                       wready,
+    input  wire [AXI_DATA_WIDTH-1:0] wdata,
+    input  wire [3:0]                wstrb,
+    input  wire                      wlast,
+    
+    // Write Response Channel
+    output reg                       bvalid,
+    input  wire                      bready,
+    output reg [1:0]                 bresp,
+    
+    // Read Address Channel
+    input  wire                      arvalid,
+    output reg                       arready,
+    input  wire [AXI_ADDR_WIDTH-1:0] araddr,
+    input  wire [7:0]                arlen,
+    input  wire [2:0]                arsize,
+    input  wire [1:0]                arburst,
+    
+    // Read Data Channel
+    output reg                       rvalid,
+    input  wire                      rready,
+    output reg [AXI_DATA_WIDTH-1:0]  rdata,
+    output reg [1:0]                 rresp,
+    output reg                       rlast
+);
+
+    // Memory array
+    reg [7:0] memory [0:MEM_DEPTH-1];
+    
+    // FSM states
+    localparam IDLE = 2'b00;
+    localparam BUSY = 2'b01;
+    localparam RESP = 2'b10;
+    
+    // FSM state registers
+    reg [1:0] write_state;
+    reg [1:0] read_state;
+    
+    // Transaction counters
+    reg [7:0] write_count;
+    reg [7:0] read_count;
+    reg [AXI_ADDR_WIDTH-1:0] write_addr;
+    reg [AXI_ADDR_WIDTH-1:0] read_addr;
+
+    // Write channel logic
+    always @(posedge aclk or negedge aresetn) begin
+        if (!aresetn) begin
+            write_state <= IDLE;
+            awready     <= 1'b0;
+            wready      <= 1'b0;
+            bvalid      <= 1'b0;
+            bresp       <= 2'b00;
+            write_count <= 8'b0;
+        end else begin
+            case (write_state)
+                IDLE: begin
+                    awready <= 1'b1;
+                    wready  <= 1'b0;
+                    if (awvalid) begin
+                        awready     <= 1'b0;
+                        write_addr  <= awaddr;
+                        write_count <= awlen + 1;
+                        write_state <= BUSY;
+                    end
+                end
+
+                BUSY: begin
+                    awready <= 1'b0;
+                    wready  <= 1'b1;
+
+                    if (wvalid) begin
+                        // Write data to memory
+                        if (wstrb[0]) memory[write_addr]   <= wdata[7:0];
+                        if (wstrb[1]) memory[write_addr+1] <= wdata[15:8];
+                        if (wstrb[2]) memory[write_addr+2] <= wdata[23:16];
+                        if (wstrb[3]) memory[write_addr+3] <= wdata[31:24];
+
+                        write_addr  <= write_addr + 4;
+                        write_count <= write_count - 1;
+
+                        if (write_count == 1) begin
+                            wready      <= 1'b0;
+                            bvalid      <= 1'b1;
+                            write_state <= RESP;
+                        end
+                    end
+                end
+
+                RESP: begin
+                    if (bready) begin
+                        bvalid      <= 1'b0;
+                        write_state <= IDLE;
+                    end
+                end
+            endcase
+        end
+    end
+
+    // Read channel logic
+    always @(posedge aclk or negedge aresetn) begin
+        if (!aresetn) begin
+            read_state <= IDLE;
+            arready    <= 1'b0;
+            rvalid     <= 1'b0;
+            rlast      <= 1'b0;
+            rresp      <= 2'b00;
+            read_count <= 8'b0;
+        end else begin
+            case (read_state)
+                IDLE: begin
+                    arready <= 1'b1;
+                    if (arvalid) begin
+                        arready    <= 1'b0;
+                        read_addr  <= araddr;
+                        read_count <= arlen + 1;
+                        read_state <= BUSY;
+                    end
+                end
+
+                BUSY: begin
+                    rvalid <= 1'b1;
+
+                    // Read data from memory
+                    rdata <= {memory[read_addr+3], memory[read_addr+2],
+                             memory[read_addr+1], memory[read_addr]};
+
+                    if (rready) begin
+                        read_addr  <= read_addr + 4;
+                        read_count <= read_count - 1;
+
+                        if (read_count == 1) begin
+                            rlast      <= 1'b1;
+                            read_state <= RESP;
+                        end
+                    end
+                end
+
+                RESP: begin
+                    if (rready) begin
+                        rvalid     <= 1'b0;
+                        rlast      <= 1'b0;
+                        read_state <= IDLE;
+                    end
+                end
+            endcase
+        end
+    end
+
+endmodule

--- a/tb/signals.rc
+++ b/tb/signals.rc
@@ -1,0 +1,2 @@
+add wave -r tb_axi4.*
+run

--- a/tb/tb_axi4.sv
+++ b/tb/tb_axi4.sv
@@ -1,0 +1,101 @@
+`timescale 1ns/1ps
+
+
+
+module tb_axi4;
+    parameter ADDR_WIDTH = 32;
+    parameter DATA_WIDTH = 32;
+    parameter MAX_BURST  = 16;
+
+    axi4_master_if #(ADDR_WIDTH, DATA_WIDTH, MAX_BURST) axi_if();
+
+    // Instantiate DUT
+    axi4_slave #(
+        .AXI_ADDR_WIDTH(ADDR_WIDTH),
+        .AXI_DATA_WIDTH(DATA_WIDTH)
+    ) dut (
+        .aclk   (axi_if.aclk),
+        .aresetn(axi_if.aresetn),
+        .awvalid(axi_if.awvalid),
+        .awready(axi_if.awready),
+        .awaddr (axi_if.awaddr),
+        .awlen  (axi_if.awlen),
+        .awsize (axi_if.awsize),
+        .awburst(axi_if.awburst),
+        .wvalid (axi_if.wvalid),
+        .wready (axi_if.wready),
+        .wdata  (axi_if.wdata),
+        .wstrb  (axi_if.wstrb),
+        .wlast  (axi_if.wlast),
+        .bvalid (axi_if.bvalid),
+        .bready (axi_if.bready),
+        .bresp  (axi_if.bresp),
+        .arvalid(axi_if.arvalid),
+        .arready(axi_if.arready),
+        .araddr (axi_if.araddr),
+        .arlen  (axi_if.arlen),
+        .arsize (axi_if.arsize),
+        .arburst(axi_if.arburst),
+        .rvalid (axi_if.rvalid),
+        .rready (axi_if.rready),
+        .rdata  (axi_if.rdata),
+        .rresp  (axi_if.rresp),
+        .rlast  (axi_if.rlast)
+    );
+
+    // clock generation
+    initial axi_if.aclk = 0;
+    always #5 axi_if.aclk = ~axi_if.aclk;
+
+    // reset generation
+    initial begin
+        axi_if.aresetn = 0;
+        axi_if.awvalid = 0;
+        axi_if.wvalid  = 0;
+        axi_if.bready  = 0;
+        axi_if.arvalid = 0;
+        axi_if.rready  = 0;
+        repeat(5) @(posedge axi_if.aclk);
+        axi_if.aresetn = 1;
+    end
+
+    // Test sequence
+    initial begin
+        integer i;
+        reg [DATA_WIDTH-1:0] rdata;
+        reg [DATA_WIDTH-1:0] burst_wdata [0:MAX_BURST-1];
+        reg [DATA_WIDTH-1:0] burst_rdata [0:MAX_BURST-1];
+
+        $display("Starting tests...");
+        // register write/read
+        axi_if.write_single(32'h0000_0000, 32'hDEADBEEF);
+        axi_if.read_single(32'h0000_0000, rdata);
+        if (rdata !== 32'hDEADBEEF) $display("Register test failed: %h", rdata);
+        else $display("Register test passed");
+
+        // burst write/read
+        for(i=0;i<4;i++) burst_wdata[i] = i+1;
+        axi_if.write_burst(32'h0000_0010, burst_wdata, 4);
+        axi_if.read_burst(32'h0000_0010, burst_rdata, 4);
+        for(i=0;i<4;i++)
+            if (burst_rdata[i] !== burst_wdata[i])
+                $display("Burst mismatch at %0d: wrote %h read %h", i, burst_wdata[i], burst_rdata[i]);
+        $display("Burst test completed");
+
+        #100;
+        $finish;
+    end
+
+    // waveform dump
+`ifndef IVERILOG
+    initial begin
+        $fsdbDumpfile("wave.fsdb");
+        $fsdbDumpvars(0, tb_axi4);
+    end
+`else
+    initial begin
+        $dumpfile("wave.vcd");
+        $dumpvars(0, tb_axi4);
+    end
+`endif
+endmodule


### PR DESCRIPTION
## Summary
- allow burst tasks in the AXI master interface to accept open arrays
- remove duplicate include of interface in testbench

## Testing
- `make run` *(fails: vcs not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e002f5db4832f9cbe341cae09c82e